### PR TITLE
Replace rubocop and foodcritic checks by cookstyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,0 @@
-LineLength:
-    Enabled: false
-SpaceBeforeFirstArg:
-    Enabled: false
-AbcSize:
-    Enabled: false
-MethodLength:
-    Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ cache: bundler
 rvm:
 - 2.2.2
 script:
-- bundle exec rubocop
-- bundle exec foodcritic --contex --epic-fail any .
+- bundle exec cookstyle
 sudo: false
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
 - 2.2.2
 script:
 - bundle exec cookstyle
+- bundle exec foodcritic --contex --epic-fail any .
 sudo: false
 notifications:
   slack:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 group :lint do
   gem 'foodcritic'
   gem 'rubocop'
+  gem 'cookstyle'
 end
 
 group :kitchen_common do


### PR DESCRIPTION
Example for replacing rubocop checks by cookstyle.

cookstyle default checks https://github.com/chef/cookstyle/blob/master/README.md